### PR TITLE
Exclude operations which CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS cannot deal with automatically

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CategoryConstructor",
 Subtitle := "Construct categories out of given ones",
-Version := "2021.10-07",
+Version := "2021.10-08",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/CategoryConstructor.gi
+++ b/gap/CategoryConstructor.gi
@@ -77,9 +77,6 @@ InstallGlobalFunction( CategoryConstructor,
               "MorphismDatum",
               "IsIdenticalToIdentityMorphism",    ## the CAP specification depends on IsEqualForMorphisms which might be different in the resulting category
               "IsIdenticalToZeroMorphism",        ## the CAP specification depends on IsEqualForMorphisms which might be different in the resulting category
-              "DirectSumCodiagonalDifference",    ## TOOD: CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS in create_func_morphism cannot deal with it yet
-              "DirectSumDiagonalDifference",      ## TOOD: CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS in create_func_morphism cannot deal with it yet
-              "FiberProductEmbeddingInDirectSum", ## TOOD: CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS in create_func_morphism cannot deal with it yet
               ];
     
     properties := CAP_INTERNAL_RETURN_OPTION_OR_DEFAULT( "properties", [ ] );
@@ -410,6 +407,14 @@ InstallGlobalFunction( CategoryConstructor,
                         Add( list_of_operations_to_install, with_given_object_name );
                     fi;
                 fi;
+                continue;
+            fi;
+            
+            # if source and range cannot be computed we cannot do anything
+            if not (
+                    IsBound( info.output_source_getter_string ) and info.can_always_compute_output_source_getter and
+                    IsBound( info.output_range_getter_string ) and info.can_always_compute_output_range_getter
+                   ) then
                 continue;
             fi;
             


### PR DESCRIPTION
The required info is now available in the method record.

This fixes the CI in LazyCategories. After https://github.com/homalg-project/CAP_project/commit/1c2009beb5ca3444a46963973b304a61b348b7a4, LazyCategories is using a different derivation for `InjectionOfCofactorOfPushout` which uses `DirectSumProjectionInPushout` which in turn is not covered by CAP_INTERNAL_GET_CORRESPONDING_OUTPUT_OBJECTS.