### PR TITLE
Turn CategoryConstructor into an operation

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CategoryConstructor",
 Subtitle := "Construct categories out of given ones",
-Version := "2021.11-04",
+Version := "2021.11-05",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/gap/CategoryConstructor.gd
+++ b/gap/CategoryConstructor.gd
@@ -40,7 +40,7 @@ DeclareInfoClass( "InfoCategoryConstructor" );
 #!  * create_func_other_morphism
 #! @Arguments nothing
 #! @Returns a &CAP; category
-DeclareGlobalFunction( "CategoryConstructor" );
+DeclareOperation( "CategoryConstructor", [ ] );
 
 ####################################
 #

--- a/gap/CategoryConstructor.gi
+++ b/gap/CategoryConstructor.gi
@@ -26,7 +26,9 @@ InstallOtherMethod( UnderlyingCell,
   IdFunc );
 
 ##
-InstallGlobalFunction( CategoryConstructor,
+InstallMethod( CategoryConstructor,
+               [ ],
+               
   function( )
     local name, CC, category_object_filter, category_morphism_filter, category_filter,
           commutative_ring, list_of_operations_to_install, skip, properties, doctrines, doc, prop,


### PR DESCRIPTION
This way, CAP can install its own version with a record as the first
argument.