### PR TITLE
Rewrite test files from MonoidalCategories

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CategoryConstructor",
 Subtitle := "Construct categories out of given ones",
-Version := "2022.01-07",
+Version := "2022.02-08",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
@@ -72,7 +72,7 @@ Dependencies := rec(
   NeededOtherPackages := [
                    [ "GAPDoc", ">= 1.5" ],
                    [ "CAP", ">= 2021.08-03" ],
-                   [ "MonoidalCategories", ">= 2021.12-10" ],
+                   [ "MonoidalCategories", ">= 2022.02-08" ],
                    [ "ToolsForHomalg", ">= 2021.11-01" ],
                    ],
   SuggestedOtherPackages := [

--- a/gap/CreateClosedMonoidalCategories.gi
+++ b/gap/CreateClosedMonoidalCategories.gi
@@ -84,7 +84,7 @@ InstallGlobalFunction( CAP_INTERNAL_FUNC_FOR_CLOSED_MONOIDAL_STRUCTURES,
     
 end );
 
-##    
+##
 InstallGlobalFunction( WriteFileForClosedMonoidalStructure,
   function( key_val_rec, package_name, files_rec )
     local dir, L, files, header, file, source, target;
@@ -94,14 +94,18 @@ InstallGlobalFunction( WriteFileForClosedMonoidalStructure,
     dir := Concatenation( PackageInfo( "MonoidalCategories" )[1].InstallationPath, "/gap/" );
     
     files := [ "ClosedMonoidalCategories_gd",
+               "ClosedMonoidalCategoriesTest_gd",
                "RigidSymmetricClosedMonoidalCategories_gd",
+               "RigidSymmetricClosedMonoidalCategoriesTest_gd",
                "ClosedMonoidalCategoriesProperties_gi",
                "ClosedMonoidalCategoriesMethodRecord_gi",
                "ClosedMonoidalCategories_gi",
+               "ClosedMonoidalCategoriesTest_gi",
                "SymmetricClosedMonoidalCategoriesProperties_gi",
                "RigidSymmetricClosedMonoidalCategoriesProperties_gi",
                "RigidSymmetricClosedMonoidalCategoriesMethodRecord_gi",
                "RigidSymmetricClosedMonoidalCategories_gi",
+               "RigidSymmetricClosedMonoidalCategoriesTest_gi",
                "ClosedMonoidalCategoriesDerivedMethods_gi",
                "SymmetricClosedMonoidalCategoriesDerivedMethods_gi",
                "RigidSymmetricClosedMonoidalCategoriesDerivedMethods_gi",

--- a/gap/CreateCoclosedMonoidalCategories.gi
+++ b/gap/CreateCoclosedMonoidalCategories.gi
@@ -84,7 +84,7 @@ InstallGlobalFunction( CAP_INTERNAL_FUNC_FOR_COCLOSED_MONOIDAL_STRUCTURES,
     
 end );
 
-##    
+##
 InstallGlobalFunction( WriteFileForCoclosedMonoidalStructure,
   function( key_val_rec, package_name, files_rec )
     local dir, L, files, header, file, source, target;
@@ -94,14 +94,18 @@ InstallGlobalFunction( WriteFileForCoclosedMonoidalStructure,
     dir := Concatenation( PackageInfo( "MonoidalCategories" )[1].InstallationPath, "/gap/" );
     
     files := [ "CoclosedMonoidalCategories_gd",
+               "CoclosedMonoidalCategoriesTest_gd",
                "RigidSymmetricCoclosedMonoidalCategories_gd",
+               "RigidSymmetricCoclosedMonoidalCategoriesTest_gd",
                "CoclosedMonoidalCategoriesProperties_gi",
                "CoclosedMonoidalCategoriesMethodRecord_gi",
                "CoclosedMonoidalCategories_gi",
+               "CoclosedMonoidalCategoriesTest_gi",
                "SymmetricCoclosedMonoidalCategoriesProperties_gi",
                "RigidSymmetricCoclosedMonoidalCategoriesProperties_gi",
                "RigidSymmetricCoclosedMonoidalCategoriesMethodRecord_gi",
                "RigidSymmetricCoclosedMonoidalCategories_gi",
+               "RigidSymmetricCoclosedMonoidalCategoriesTest_gi",
                "CoclosedMonoidalCategoriesDerivedMethods_gi",
                "SymmetricCoclosedMonoidalCategoriesDerivedMethods_gi",
                "RigidSymmetricCoclosedMonoidalCategoriesDerivedMethods_gi",

--- a/gap/CreateCoclosedMonoidalCategories.gi
+++ b/gap/CreateCoclosedMonoidalCategories.gi
@@ -41,7 +41,7 @@ InstallGlobalFunction( CAP_INTERNAL_FUNC_FOR_COCLOSED_MONOIDAL_STRUCTURES,
            "otimes",
            "tensor_product",
            "tensorSproduct",
-           "coHom_tensor",
+           "cohom_tensor",
            "coHom",
            "CoclosedSMonoidal",
            "TensorProductOnObjectsBCcat",
@@ -66,7 +66,7 @@ InstallGlobalFunction( CAP_INTERNAL_FUNC_FOR_COCLOSED_MONOIDAL_STRUCTURES,
                    ], L );
     
     Add( L, [ "tensor product", key_val_rec.tensorSproduct ] );
-    Add( L, [ "coHom tensor", key_val_rec.coHom_tensor ] );
+    Add( L, [ "cohom tensor", key_val_rec.cohom_tensor ] );
     Add( L, [ "\\\underline{coHom}", key_val_rec.coHom ] );
     
     if IsBound( key_val_rec.replace ) then

--- a/gap/CreateMonoidalCategories.gi
+++ b/gap/CreateMonoidalCategories.gi
@@ -77,7 +77,7 @@ InstallGlobalFunction( CAP_INTERNAL_FUNC_FOR_MONOIDAL_STRUCTURES,
     
 end );
 
-##    
+##
 InstallGlobalFunction( WriteFileForMonoidalStructure,
   function( key_val_rec, package_name, files_rec )
     local dir, L, files, header, file, source, target;
@@ -87,18 +87,24 @@ InstallGlobalFunction( WriteFileForMonoidalStructure,
     dir := Concatenation( PackageInfo( "MonoidalCategories" )[1].InstallationPath, "/gap/" );
     
     files := [ "MonoidalCategoriesTensorProductAndUnit_gd",
+               "MonoidalCategoriesTensorProductAndUnitTest_gd",
                "MonoidalCategories_gd",
+               "MonoidalCategoriesTest_gd",
                "AdditiveMonoidalCategories_gd",
                "BraidedMonoidalCategories_gd",
+               "BraidedMonoidalCategoriesTest_gd",
                "MonoidalCategoriesTensorProductAndUnitMethodRecord_gi",
                "MonoidalCategoriesTensorProductAndUnit_gi",
+               "MonoidalCategoriesTensorProductAndUnitTest_gi",
                "MonoidalCategoriesMethodRecord_gi",
                "MonoidalCategories_gi",
+               "MonoidalCategoriesTest_gi",
                "AdditiveMonoidalCategoriesMethodRecord_gi",
                "AdditiveMonoidalCategories_gi",
                "BraidedMonoidalCategoriesProperties_gi",
                "BraidedMonoidalCategoriesMethodRecord_gi",
                "BraidedMonoidalCategories_gi",
+               "BraidedMonoidalCategoriesTest_gi",
                "SymmetricMonoidalCategoriesProperties_gi",
                "MonoidalCategoriesDerivedMethods_gi",
                "AdditiveMonoidalCategoriesDerivedMethods_gi",

--- a/gap/CreateMonoidalCategories.gi
+++ b/gap/CreateMonoidalCategories.gi
@@ -73,6 +73,17 @@ InstallGlobalFunction( CAP_INTERNAL_FUNC_FOR_MONOIDAL_STRUCTURES,
     Add( L, [ "Additive ", key_val_rec.AdditiveS ] );
     Add( L, [ "Braided ", key_val_rec.BraidedS ] );
     
+    if IsBound( key_val_rec.replace ) then
+        Append( L, key_val_rec.replace );
+    fi;
+    
+    if IsBound( key_val_rec.safe_replace ) then
+        L := Concatenation(
+                     List( key_val_rec.safe_replace, r -> [ r[1], ShaSum( r[1] ) ] ), ## detect at the very beginning and replace by sha's (order is important!)
+                     L,
+                     List( key_val_rec.safe_replace, r -> [ ShaSum( r[1] ), r[2] ] ) ); ## safely replace the sha's at the very end
+    fi;
+    
     return L;
     
 end );


### PR DESCRIPTION
This originates from https://github.com/homalg-project/CAP_project/pull/823

But the rewriting does not produce the correct code: The test files use the closed and coclosed variants of an operation, however, only one version will be rewritten. For example, this code

https://github.com/homalg-project/CAP_project/blob/master/MonoidalCategories/gap/ClosedMonoidalCategoriesTest.gi#L99-L103

is rewritten as

```gap
            hom_ab := ExponentialOnObjects( a, b );
            hom_ba := ExponentialOnObjects( b, a );
            
            cohom_ab_op := InternalCoHomOnObjects( a_op, b_op );
            cohom_ba_op := InternalCoHomOnObjects( b_op, a_op );
```

so this is the same problem which we had with the MethodRecords a while ago.
