### PR TITLE
Topos -> MonoidalCategories in test

### DIFF
--- a/examples/TerminalCategoryWithMultipleObjects.g
+++ b/examples/TerminalCategoryWithMultipleObjects.g
@@ -8,27 +8,27 @@ LoadPackage( "SubcategoriesForCAP" );
 
 #! @Example
 T := TerminalCategoryWithMultipleObjects( );
-#! TerminalCategoryWithMultipleObjects( )
+#! TerminalCategoryWithMultipleObjects
 a := "a" / T;
-#! <An object in TerminalCategoryWithMultipleObjects( )>
+#! <An object in TerminalCategoryWithMultipleObjects>
 Display( a );
 #! a
 IsWellDefined( a );
 #! true
 aa := ObjectConstructor( T, "a" );
-#! <An object in TerminalCategoryWithMultipleObjects( )>
+#! <An object in TerminalCategoryWithMultipleObjects>
 Display( aa );
 #! a
 a = aa;
 #! true
 b := "b" / T;
-#! <An object in TerminalCategoryWithMultipleObjects( )>
+#! <An object in TerminalCategoryWithMultipleObjects>
 Display( b );
 #! b
 a = b;
 #! false
 t := TensorProduct( a, b );
-#! <An object in TerminalCategoryWithMultipleObjects( )>
+#! <An object in TerminalCategoryWithMultipleObjects>
 Display( t );
 #! TensorProductOnObjects
 a = t;
@@ -36,7 +36,7 @@ a = t;
 TensorProduct( a, a ) = t;
 #! true
 m := MorphismConstructor( a, "m", b );
-#! <A morphism in TerminalCategoryWithMultipleObjects( )>
+#! <A morphism in TerminalCategoryWithMultipleObjects>
 Display( m );
 #! a
 #! |
@@ -46,7 +46,7 @@ Display( m );
 IsWellDefined( m );
 #! true
 n := MorphismConstructor( a, "n", b );
-#! <A morphism in TerminalCategoryWithMultipleObjects( )>
+#! <A morphism in TerminalCategoryWithMultipleObjects>
 Display( n );
 #! a
 #! |
@@ -60,7 +60,7 @@ IsCongruentForMorphisms( m, n );
 m = n;
 #! true
 id := IdentityMorphism( a );
-#! <An identity morphism in TerminalCategoryWithMultipleObjects( )>
+#! <An identity morphism in TerminalCategoryWithMultipleObjects>
 Display( id );
 #! a
 #! |
@@ -72,7 +72,7 @@ m = id;
 id = MorphismConstructor( a, "xyz", a );
 #! true
 z := ZeroMorphism( a, a );
-#! <A zero morphism in TerminalCategoryWithMultipleObjects( )>
+#! <A zero morphism in TerminalCategoryWithMultipleObjects>
 Display( z );
 #! a
 #! |

--- a/gap/TerminalCategory.gi
+++ b/gap/TerminalCategory.gi
@@ -135,7 +135,7 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
     morphism_datum := { cat, morphism } -> fail;
     
     T := CategoryConstructor( :
-                 name := "TerminalCategoryWithMultipleObjects( )",
+                 name := "TerminalCategoryWithMultipleObjects",
                  category_filter := IsTerminalCategory and IsTerminalCategoryWithMultipleObjects,
                  category_object_filter := IsCapTerminalCategoryObjectRep,
                  category_morphism_filter := IsCapTerminalCategoryMorphismRep,

--- a/tst/TerminalCategoryMonoidal.tst
+++ b/tst/TerminalCategoryMonoidal.tst
@@ -7,7 +7,7 @@ gap> START_TEST("TerminalCategoryMonoidal.tst");
 
 gap> LoadPackage("CategoryConstructor", false);
 true
-gap> LoadPackage("Toposes", false);
+gap> LoadPackage("MonoidalCategories", false);
 true
 
 gap> T := TerminalCategoryWithMultipleObjects( );;


### PR DESCRIPTION
- fab6173baf8afe0e2ad97a71602cf7cebe12b5fb Is a copy paste mistake...
- 6cca5ba6e0dcd5f4b5f95a0884890807426a4ee7 I don't know if the parentheses are on purpose, but for example in `FinSets` we have: 
```gap
gap> fs := FinSet( 2 );
<An object in SkeletalFinSets>
```
but in the terminal category we have:
```gap
gap> "2" / T;
<An object in TerminalCategoryWithMultipleObjects()>
```
notice the parentheses at the end. If it's on purpose, I'll take it back.