### PR TITLE
TerminalCategoryWithMultipleObjects now uses CAP's CategoryConstructor

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "CategoryConstructor",
 Subtitle := "Construct categories out of given ones",
-Version := "2022.05-03",
+Version := "2022.05-04",
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",

--- a/examples/TerminalCategoryWithMultipleObjects.g
+++ b/examples/TerminalCategoryWithMultipleObjects.g
@@ -10,14 +10,12 @@ LoadPackage( "SubcategoriesForCAP" );
 T := TerminalCategoryWithMultipleObjects( );
 #! TerminalCategoryWithMultipleObjects
 InfoOfInstalledOperationsOfCategory( T );
-#! 133 primitive operations were used to derive 561 operations for this category
+#! 116 primitive operations were used to derive 471 operations for this category
 #! which constructively
 #! * IsEquippedWithHomomorphismStructure
 #! * IsLinearCategoryOverCommutativeRing
 #! * IsCodistributiveCocartesianCategory
 #! * IsBicartesianCoclosedCategory
-#! * IsAbelianCategoryWithEnoughInjectives
-#! * IsAbelianCategoryWithEnoughProjectives
 #! * IsRigidSymmetricClosedMonoidalCategory
 #! * IsRigidSymmetricCoclosedMonoidalCategory
 #! * IsElementaryTopos

--- a/gap/TerminalCategory.gi
+++ b/gap/TerminalCategory.gi
@@ -133,14 +133,13 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
     
     morphism_datum := { cat, morphism } -> fail;
     
-    T := CategoryConstructor( :
+    T := CategoryConstructor( rec(
                  name := "TerminalCategoryWithMultipleObjects",
                  category_filter := IsTerminalCategory and IsTerminalCategoryWithMultipleObjects,
                  category_object_filter := IsCapTerminalCategoryObjectRep,
                  category_morphism_filter := IsCapTerminalCategoryMorphismRep,
-                 commutative_ring := HomalgRingOfIntegers( ),
+                 commutative_ring_of_linear_category := HomalgRingOfIntegers( ),
                  properties := properties,
-                 is_monoidal := true,
                  list_of_operations_to_install := list_of_operations_to_install,
                  create_func_bool := create_func_bool,
                  create_func_object := create_func_object,
@@ -149,9 +148,8 @@ InstallGlobalFunction( TerminalCategoryWithMultipleObjects,
                  object_constructor := object_constructor,
                  object_datum := object_datum,
                  morphism_constructor := morphism_constructor,
-                 morphism_datum := morphism_datum,
-                 category_as_first_argument := true
-                 );
+                 morphism_datum := morphism_datum
+                 ) );
     
     ##
     AddIsWellDefinedForObjects( T,


### PR DESCRIPTION
which is more restrictive